### PR TITLE
OpenAI Model as an environment variable and default set to gpt-3.5-turbo

### DIFF
--- a/completion.py
+++ b/completion.py
@@ -29,8 +29,9 @@ class Completion:
         return self._state
 
     def _complete_prompt(self) -> str:
+        model = os.getenv('OPENAI_MODEL') or 'gpt-3.5-turbo'
         response = self._openai_client.Completion.create(
-            model="text-davinci-003", prompt=self._prompt.text, max_tokens=1024
+            model=model, prompt=self._prompt.text, max_tokens=1024
         )
         return response.choices[0].text
 


### PR DESCRIPTION
The model text-davinci-003 is deprecated. I added an env variable so the user can choose the model he wants. If the env variable isn't passed, it will use gpt-3.5-turbo by default.